### PR TITLE
Add clipping to rotor_vel

### DIFF
--- a/crazyflow/sim/integration.py
+++ b/crazyflow/sim/integration.py
@@ -1,3 +1,15 @@
+"""Numerical integrators for the simulation dynamics.
+
+All integrators advance the full drone state, including the rotor state ``rotor_vel``, by one
+simulation step.
+
+Note:
+    The rotor limits are only enforced by clipping ``rotor_vel`` after the integration (see
+    [clip_rotor_vel][crazyflow.sim.sim.clip_rotor_vel]). Higher order integration methods like RK4
+    evaluate the dynamics at intermediate states that are not clipped, so the ``rotor_vel`` seen by
+    the model can transiently exceed the limits within a single step.
+"""
+
 from enum import StrEnum
 from functools import partial
 from typing import Callable

--- a/crazyflow/sim/integration.py
+++ b/crazyflow/sim/integration.py
@@ -1,8 +1,5 @@
 """Numerical integrators for the simulation dynamics.
 
-All integrators advance the full drone state, including the rotor state ``rotor_vel``, by one
-simulation step.
-
 Note:
     The rotor limits are only enforced by clipping ``rotor_vel`` after the integration (see
     [clip_rotor_vel][crazyflow.sim.sim.clip_rotor_vel]). Higher order integration methods like RK4

--- a/crazyflow/sim/integration.py
+++ b/crazyflow/sim/integration.py
@@ -152,7 +152,7 @@ def _integrate(
     return next_pos, next_quat, next_vel, next_ang_vel, next_rotor_vel
 
 
-@partial(vectorize, signature="(3),(4),(3),(3),(M),(3),(3),(M)->(3),(4),(3),(3),(M)", excluded=[7])
+@partial(vectorize, signature="(3),(4),(3),(3),(M),(3),(3),(M)->(3),(4),(3),(3),(M)", excluded=[8])
 def _integrate_symplectic(
     pos: Array,
     quat: Array,

--- a/crazyflow/sim/integration.py
+++ b/crazyflow/sim/integration.py
@@ -3,8 +3,8 @@
 Note:
     State limits are enforced by clipping after the integration (see e.g.
     [clip_rotor_vel][crazyflow.sim.sim.clip_rotor_vel]). The derivatives are unclipped. Higher order
-    integration methods like RK4 evaluate the dynamics at intermediate states, so derivatives seen by
-    the model can transiently exceed the limits within a single step.
+    integration methods like RK4 evaluate the dynamics at intermediate states, so derivatives seen
+    by the model can transiently exceed the limits within a single step.
 """
 
 from enum import StrEnum

--- a/crazyflow/sim/integration.py
+++ b/crazyflow/sim/integration.py
@@ -1,9 +1,9 @@
 """Numerical integrators for the simulation dynamics.
 
 Note:
-    The rotor limits are only enforced by clipping ``rotor_vel`` after the integration (see
-    [clip_rotor_vel][crazyflow.sim.sim.clip_rotor_vel]). Higher order integration methods like RK4
-    evaluate the dynamics at intermediate states that are not clipped, so the ``rotor_vel`` seen by
+    State limits are enforced by clipping after the integration (see e.g.
+    [clip_rotor_vel][crazyflow.sim.sim.clip_rotor_vel]). The derivatives are unclipped. Higher order
+    integration methods like RK4 evaluate the dynamics at intermediate states, so derivatives seen by
     the model can transiently exceed the limits within a single step.
 """
 

--- a/crazyflow/sim/sim.py
+++ b/crazyflow/sim/sim.py
@@ -22,6 +22,8 @@ from crazyflow.control.mellinger import (
     control_force_torque2rotor_vel,
     control_state2attitude,
 )
+from crazyflow.control.transform import motor_force2rotor_vel
+from crazyflow.drones import load_params as load_drone_params
 from crazyflow.dynamics import Dynamics
 from crazyflow.dynamics.first_principles import sim_dynamics as first_principles_dynamics
 from crazyflow.dynamics.so_rpy import sim_dynamics as so_rpy_dynamics
@@ -145,8 +147,16 @@ class Sim:
         # simulation pipeline.
         for name, fn in build_control_fns(self.control, self.dynamics):
             append_fn(self.step_pipeline, fn, name=name)
-        integrate_fn = select_integrate_fn(self.integrator, select_dynamics_fn(self.dynamics))
+        # Keep the rotor state (RPM or thrust, see ``rotor_vel_limits``) within its physical limits.
+        # Inside the integration, the derivative is clamped at the limits so that the integrator
+        # does not push the state beyond them. Since the clamp only acts at the limits, a single
+        # step can still overshoot from below, which the clip after the integration removes.
+        lower, upper = rotor_vel_limits(self.dynamics, self.drone)
+        dynamics_fn = select_dynamics_fn(self.dynamics)
+        integrate_fn = select_integrate_fn(self.integrator, dynamics_fn, (lower, upper))
         append_fn(self.step_pipeline, integrate_fn, name="integration")
+        clip_fn = partial(clip_rotor_vel, lower=lower, upper=upper)
+        append_fn(self.step_pipeline, clip_fn, name="clip_rotor_vel")
         append_fn(self.step_pipeline, increment_steps)
         # We never drop below -0.001 (drones can't pass through the floor). We use -0.001 to
         # enable checks for negative z sign
@@ -600,9 +610,17 @@ def select_dynamics_fn(dynamics: Dynamics) -> Callable[[SimData], SimData]:
 
 
 def select_integrate_fn(
-    integrator: Integrator, dynamics_fn: Callable[[SimData], SimData]
+    integrator: Integrator,
+    dynamics_fn: Callable[[SimData], SimData],
+    rotor_vel_limits: tuple[Array | float, Array | float],
 ) -> Callable[[SimData], SimData]:
-    """Select the integration function for the given dynamics and integrator mode."""
+    """Select the integration function for the given dynamics and integrator mode.
+
+    The dynamics function is wrapped with [clip_rotor_acc][crazyflow.sim.sim.clip_rotor_acc] so that
+    the integrator never pushes ``rotor_vel`` beyond ``rotor_vel_limits``.
+    """
+    lower, upper = rotor_vel_limits
+    dynamics_fn = partial(clip_rotor_acc, deriv_fn=dynamics_fn, lower=lower, upper=upper)
     match integrator:
         case Integrator.euler:
             integrate_fn = euler
@@ -668,6 +686,40 @@ def clip_floor_pos(data: SimData) -> SimData:
         jnp.where(clip[..., None], 0, data.states.vel[..., :3])
     )
     return data.replace(states=data.states.replace(pos=clip_pos, vel=clip_vel))
+
+
+def rotor_vel_limits(dynamics: Dynamics, drone: str) -> tuple[Array | float, Array | float]:
+    """Limits of ``rotor_vel`` in RPM (first principles) or collective thrust in N (others)."""
+    params = load_drone_params(drone)
+    thrust_min, thrust_max = params["thrust_min"], params["thrust_max"]
+    if dynamics == Dynamics.first_principles:
+        rpm = motor_force2rotor_vel(jnp.asarray([thrust_min, thrust_max]), params["rpm2thrust"])
+        return rpm[0], rpm[1]
+    return 4 * thrust_min, 4 * thrust_max
+
+
+def clip_rotor_vel(data: SimData, lower: Array | float, upper: Array | float) -> SimData:
+    """Clip ``rotor_vel`` to ``[lower, upper]``."""
+    rotor_vel = jnp.clip(data.states.rotor_vel, lower, upper)
+    return data.replace(states=data.states.replace(rotor_vel=rotor_vel))
+
+
+def clip_rotor_acc(
+    data: SimData,
+    deriv_fn: Callable[[SimData], SimData],
+    lower: Array | float,
+    upper: Array | float,
+) -> SimData:
+    """Evaluate ``deriv_fn`` and clamp ``rotor_acc`` at the ``rotor_vel`` limits.
+
+    ``rotor_acc`` is clamped to ``<= 0`` at the upper and ``>= 0`` at the lower limit, otherwise the
+    integrator would push ``rotor_vel`` beyond its limits.
+    """
+    data = deriv_fn(data)
+    rotor_vel, rotor_acc = data.states.rotor_vel, data.states_deriv.rotor_acc
+    rotor_acc = jnp.where(rotor_vel >= upper, jnp.minimum(rotor_acc, 0.0), rotor_acc)
+    rotor_acc = jnp.where(rotor_vel <= lower, jnp.maximum(rotor_acc, 0.0), rotor_acc)
+    return data.replace(states_deriv=data.states_deriv.replace(rotor_acc=rotor_acc))
 
 
 @partial(jax.jit, static_argnames="device")

--- a/crazyflow/sim/sim.py
+++ b/crazyflow/sim/sim.py
@@ -147,14 +147,10 @@ class Sim:
         # simulation pipeline.
         for name, fn in build_control_fns(self.control, self.dynamics):
             append_fn(self.step_pipeline, fn, name=name)
-        # Keep the rotor state (RPM or thrust, see ``rotor_vel_limits``) within its physical limits.
-        # Inside the integration, the derivative is clamped at the limits so that the integrator
-        # does not push the state beyond them. Since the clamp only acts at the limits, a single
-        # step can still overshoot from below, which the clip after the integration removes.
-        lower, upper = rotor_vel_limits(self.dynamics, self.drone)
-        dynamics_fn = select_dynamics_fn(self.dynamics)
-        integrate_fn = select_integrate_fn(self.integrator, dynamics_fn, (lower, upper))
+        integrate_fn = select_integrate_fn(self.integrator, select_dynamics_fn(self.dynamics))
         append_fn(self.step_pipeline, integrate_fn, name="integration")
+        # Keep the rotor state (RPM or thrust, see ``rotor_vel_limits``) within its physical limits
+        lower, upper = rotor_vel_limits(self.dynamics, self.drone)
         clip_fn = partial(clip_rotor_vel, lower=lower, upper=upper)
         append_fn(self.step_pipeline, clip_fn, name="clip_rotor_vel")
         append_fn(self.step_pipeline, increment_steps)
@@ -610,17 +606,9 @@ def select_dynamics_fn(dynamics: Dynamics) -> Callable[[SimData], SimData]:
 
 
 def select_integrate_fn(
-    integrator: Integrator,
-    dynamics_fn: Callable[[SimData], SimData],
-    rotor_vel_limits: tuple[Array | float, Array | float],
+    integrator: Integrator, dynamics_fn: Callable[[SimData], SimData]
 ) -> Callable[[SimData], SimData]:
-    """Select the integration function for the given dynamics and integrator mode.
-
-    The dynamics function is wrapped with [clip_rotor_acc][crazyflow.sim.sim.clip_rotor_acc] so that
-    the integrator never pushes ``rotor_vel`` beyond ``rotor_vel_limits``.
-    """
-    lower, upper = rotor_vel_limits
-    dynamics_fn = partial(clip_rotor_acc, deriv_fn=dynamics_fn, lower=lower, upper=upper)
+    """Select the integration function for the given dynamics and integrator mode."""
     match integrator:
         case Integrator.euler:
             integrate_fn = euler
@@ -702,24 +690,6 @@ def clip_rotor_vel(data: SimData, lower: Array | float, upper: Array | float) ->
     """Clip ``rotor_vel`` to ``[lower, upper]``."""
     rotor_vel = jnp.clip(data.states.rotor_vel, lower, upper)
     return data.replace(states=data.states.replace(rotor_vel=rotor_vel))
-
-
-def clip_rotor_acc(
-    data: SimData,
-    deriv_fn: Callable[[SimData], SimData],
-    lower: Array | float,
-    upper: Array | float,
-) -> SimData:
-    """Evaluate ``deriv_fn`` and clamp ``rotor_acc`` at the ``rotor_vel`` limits.
-
-    ``rotor_acc`` is clamped to ``<= 0`` at the upper and ``>= 0`` at the lower limit, otherwise the
-    integrator would push ``rotor_vel`` beyond its limits.
-    """
-    data = deriv_fn(data)
-    rotor_vel, rotor_acc = data.states.rotor_vel, data.states_deriv.rotor_acc
-    rotor_acc = jnp.where(rotor_vel >= upper, jnp.minimum(rotor_acc, 0.0), rotor_acc)
-    rotor_acc = jnp.where(rotor_vel <= lower, jnp.maximum(rotor_acc, 0.0), rotor_acc)
-    return data.replace(states_deriv=data.states_deriv.replace(rotor_acc=rotor_acc))
 
 
 @partial(jax.jit, static_argnames="device")

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -51,6 +51,17 @@ Because the simulator is built entirely from JAX operations, `jax.grad` can diff
 
 ---
 
+## Gradients and state clipping
+
+Hard state clips such as the `clip_rotor_vel` stage zero the gradients while the state is saturated. This example ramps a motor command beyond the rotor limits and compares the rotor state and the gradient of the vertical acceleration w.r.t. the command for three options: the default clip, a straight-through clip (clipped forward pass, unclipped gradients), and no clip. Replacing the default clip with the straight-through variant can help gradient-based methods such as trajectory optimization or policy learning, which would otherwise receive zero gradients whenever the motors saturate.
+
+<!-- notest: imported script, covered by tests/integration/test_examples.py -->
+```{ .python notest }
+--8<-- "examples/jax/gradient_clipping.py"
+```
+
+---
+
 ## Sharding across devices
 
 We can also distribute the simulation across devices. The host backend is asked for four logical devices. We then compare this against running on a single device. See [Sharding](../user-guide/sharding.md) for the details.

--- a/docs/user-guide/pipelines.md
+++ b/docs/user-guide/pipelines.md
@@ -132,7 +132,7 @@ sim.build_step_fn()
 ```
 
 !!! note
-    The rotor limits are enforced solely by the `clip_rotor_vel` stage, which clips the rotor state after each integration step. Higher order integration methods like RK4 evaluate the dynamics at intermediate, unclipped states, so the `rotor_vel` seen by the model can transiently exceed the limits within a single step.
+    The rotor limits are enforced by the `clip_rotor_vel` stage, which clips the rotor state after each integration step. Higher order integration methods like RK4 evaluate the dynamics at intermediate, unclipped states, so the `rotor_vel` seen by the model can transiently exceed the limits within a single step.
 
 ## Writing a custom stage
 

--- a/docs/user-guide/pipelines.md
+++ b/docs/user-guide/pipelines.md
@@ -22,7 +22,7 @@ Both pipelines are constructed at `Sim` initialisation and compiled into a singl
 `sim.step_pipeline` contains multiple stages by default:
 
 1. **Control functions** — convert the staged command through the control hierarchy (state → attitude → force/torque → rotor velocities, depending on the selected mode)
-2. **Integrator** (`integration`) — advance the ODE one dynamics step (Euler, RK4, or symplectic Euler). `clip_rotor_acc` clamps the rotor derivative at the physical motor limits so the integrator cannot push the state beyond them
+2. **Integrator** (`integration`) — advance the ODE one dynamics step (Euler, RK4, or symplectic Euler)
 3. **Rotor clip** (`clip_rotor_vel`) — clip the motor speeds (first principles) or the collective thrust (fitted models) to the physical limits of the motors
 4. **Step counter** (`increment_steps`) — increment `data.core.steps`
 5. **Floor clip** (`clip_floor_pos`) — prevent drones from passing through the floor
@@ -132,7 +132,7 @@ sim.build_step_fn()
 ```
 
 !!! note
-    The rotor limits cannot be removed this way. `clip_rotor_vel` is a regular stage, but `clip_rotor_acc` is part of the `integration` stage and clamps the rotor derivative regardless of whether `clip_rotor_vel` is present. To lift the limits, increase `thrust_min` / `thrust_max` of the drone in `crazyflow/drones/params.toml` instead.
+    The rotor limits are enforced solely by the `clip_rotor_vel` stage, which clips the rotor state after each integration step. Higher order integration methods like RK4 evaluate the dynamics at intermediate, unclipped states, so the `rotor_vel` seen by the model can transiently exceed the limits within a single step.
 
 ## Writing a custom stage
 

--- a/docs/user-guide/pipelines.md
+++ b/docs/user-guide/pipelines.md
@@ -22,15 +22,16 @@ Both pipelines are constructed at `Sim` initialisation and compiled into a singl
 `sim.step_pipeline` contains multiple stages by default:
 
 1. **Control functions** — convert the staged command through the control hierarchy (state → attitude → force/torque → rotor velocities, depending on the selected mode)
-2. **Integrator** (`integration`) — advance the ODE one dynamics step (Euler, RK4, or symplectic Euler)
-3. **Step counter** (`increment_steps`) — increment `data.core.steps`
-4. **Floor clip** (`clip_floor_pos`) — prevent drones from passing through the floor
+2. **Integrator** (`integration`) — advance the ODE one dynamics step (Euler, RK4, or symplectic Euler). `clip_rotor_acc` clamps the rotor derivative at the physical motor limits so the integrator cannot push the state beyond them
+3. **Rotor clip** (`clip_rotor_vel`) — clip the motor speeds (first principles) or the collective thrust (fitted models) to the physical limits of the motors
+4. **Step counter** (`increment_steps`) — increment `data.core.steps`
+5. **Floor clip** (`clip_floor_pos`) — prevent drones from passing through the floor
 
 ```pycon
 >>> from crazyflow.sim import Sim
 >>> sim = Sim()
 >>> print(tuple(sim.step_pipeline.keys()))
-('attitude_controller', 'force_torque_controller', 'integration', 'increment_steps', 'clip_floor_pos')
+('attitude_controller', 'force_torque_controller', 'integration', 'clip_rotor_vel', 'increment_steps', 'clip_floor_pos')
 
 ```
 
@@ -129,6 +130,9 @@ sim = Sim()
 remove_fn(sim.step_pipeline, "clip_floor_pos")
 sim.build_step_fn()
 ```
+
+!!! note
+    The rotor limits cannot be removed this way. `clip_rotor_vel` is a regular stage, but `clip_rotor_acc` is part of the `integration` stage and clamps the rotor derivative regardless of whether `clip_rotor_vel` is present. To lift the limits, increase `thrust_min` / `thrust_max` of the drone in `crazyflow/drones/params.toml` instead.
 
 ## Writing a custom stage
 

--- a/docs/user-guide/sim-overview.md
+++ b/docs/user-guide/sim-overview.md
@@ -82,7 +82,7 @@ sim.step(sim.freq // sim.control_freq)  # 500 // 100 = 5 dynamics steps, control
 
 ## The step and reset pipelines
 
-Each call to `sim.step()` runs `sim.step_pipeline`, an ordered collection of named, pure JAX functions that transform `SimData`. By default it contains the control conversion functions, the numerical integrator, a step counter, and a floor clip. Similarly, `sim.reset_pipeline` is applied during `sim.reset()` and is empty by default.
+Each call to `sim.step()` runs `sim.step_pipeline`, an ordered collection of named, pure JAX functions that transform `SimData`. By default it contains the control conversion functions, the numerical integrator, a clip of the rotor state to the physical motor limits, a step counter, and a floor clip. Similarly, `sim.reset_pipeline` is applied during `sim.reset()` and is empty by default.
 
 Both pipelines can be extended with custom functions for disturbances, domain randomization, or logging without modifying the core simulator.
 

--- a/examples/jax/gradient_clipping.py
+++ b/examples/jax/gradient_clipping.py
@@ -1,0 +1,115 @@
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from numpy.typing import NDArray
+
+import crazyflow.sim.functional as F
+from crazyflow.control import Control
+from crazyflow.sim import Sim
+from crazyflow.sim.data import SimData
+from crazyflow.sim.pipeline import remove_fn, replace_fn
+from crazyflow.sim.sim import rotor_vel_limits
+
+
+def clip_rotor_vel_nonblocking(data: SimData, lower: float, upper: float) -> SimData:
+    # Straight-through estimator: x + stop_gradient(clip(x) - x) evaluates to clip(x) in the
+    # forward pass, while its derivative w.r.t. x is 1 in the backward pass
+    rotor_vel = data.states.rotor_vel
+    rotor_vel = rotor_vel + jax.lax.stop_gradient(jnp.clip(rotor_vel, lower, upper) - rotor_vel)
+    return data.replace(states=data.states.replace(rotor_vel=rotor_vel))
+
+
+def rollout(sim: Sim, cmds: NDArray) -> tuple[NDArray, NDArray]:
+    step_fn = sim.build_step_fn()
+
+    # The command only enters the acceleration through the rotor state of the *next* step, so we
+    # measure the acceleration with a one-step lookahead while the outer loop advances by a single
+    # step per command
+    def acc_z(cmd: jax.Array, data: SimData) -> tuple[jax.Array, SimData]:
+        data = F.rotor_vel_control(data, jnp.full((1, 1, 4), cmd))
+        data = step_fn(data, 1)
+        lookahead = step_fn(data, 1)
+        acc = (lookahead.states.vel[0, 0, 2] - data.states.vel[0, 0, 2]) * sim.freq
+        return acc, data
+
+    grad_fn = jax.jit(jax.value_and_grad(acc_z, has_aux=True))
+
+    data, rotor_vel, grads = sim.data, [], []
+    for cmd in cmds:
+        (_, data), grad = grad_fn(jnp.float32(cmd), data)
+        rotor_vel.append(data.states.rotor_vel[0, 0, 0])
+        grads.append(grad)
+    return np.array(rotor_vel), np.array(grads)
+
+
+def main(plot: bool = False):
+    sim = Sim(control=Control.rotor_vel)
+    lower, upper = rotor_vel_limits(sim.dynamics, sim.drone)
+    # Start in the air so that the drone never reaches the floor, where the floor clipping would
+    # zero the velocity and kill the gradients (see gradient.py)
+    sim.data = sim.data.replace(
+        states=sim.data.states.replace(pos=sim.data.states.pos.at[..., 2].set(2.0))
+    )
+
+    # Motor command (RPM): ramp up beyond the upper limit, hold, ramp back down to zero
+    ramp = float(upper) + 10_000
+    n = 250  # 0.5 s per segment at 500 Hz
+    cmds = np.concatenate([np.linspace(0, ramp, n), np.full(n, ramp), np.linspace(ramp, 0, n)])
+
+    # Option 1: keep the clipping as is. The rotor state respects the limits, but the gradient is
+    # zero while the state is saturated
+    results = {"clip (default)": rollout(sim, cmds)}
+
+    # Option 2: clip the state in the forward pass, but keep the gradients flowing in the backward
+    # pass (straight-through estimator)
+    clip_fn = partial(clip_rotor_vel_nonblocking, lower=lower, upper=upper)
+    replace_fn(sim.step_pipeline, clip_fn, "clip_rotor_vel")
+    results["nonblocking clip"] = rollout(sim, cmds)
+
+    # Option 3: remove the clipping. Gradients always flow, but the state can leave the limits
+    remove_fn(sim.step_pipeline, "clip_rotor_vel")
+    results["no clip"] = rollout(sim, cmds)
+
+    sim.close()
+    if plot:
+        plot_results(cmds, results, float(lower), float(upper), sim.freq)
+
+
+def plot_results(
+    cmds: NDArray,
+    results: dict[str, tuple[NDArray, NDArray]],
+    lower: float,
+    upper: float,
+    freq: int,
+):
+    # Only import if plotting is desired to avoid a dependency on matplotlib
+    import matplotlib.pyplot as plt
+
+    t = np.arange(len(cmds)) / freq
+    fig, (ax_state, ax_grad) = plt.subplots(1, 2, sharex="all", figsize=(12, 5))
+    ax_state.plot(t, cmds, label="command", color="gray", linestyle=":")
+    # The forward pass of the nonblocking clip is identical to the default clip, so we plot it
+    # dashed to keep both curves visible
+    styles = {"nonblocking clip": {"linestyle": "--"}}
+    for name, (rotor_vel, grads) in results.items():
+        ax_state.plot(t, rotor_vel, label=name, **styles.get(name, {}))
+        ax_grad.plot(t, grads, label=name, **styles.get(name, {}))
+    for limit in (lower, upper):
+        ax_state.axhline(limit, color="black", linestyle="--", linewidth=0.8)
+    ax_state.set_title("Rotor state")
+    ax_state.set_ylabel("rotor_vel (RPM)")
+    ax_grad.set_title("Gradient d acc_z / d cmd")
+    ax_grad.set_ylabel("(m/s$^2$) / RPM")
+    for ax in (ax_state, ax_grad):
+        ax.set_xlabel("Time (s)")
+        ax.legend()
+        ax.grid(True)
+    fig.suptitle("Rotor state clipping and its effect on gradients")
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main(plot=True)

--- a/tests/unit/test_sim.py
+++ b/tests/unit/test_sim.py
@@ -398,48 +398,43 @@ def test_floor_penetration(dynamics: Dynamics):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("integrator", Integrator)
+def test_rotor_vel_clip(integrator: Integrator):
+    """Test that the first-principles rotor state saturates at its physical limits."""
+    sim = Sim(
+        dynamics=Dynamics.first_principles,
+        control=Control.rotor_vel,
+        integrator=integrator,
+        device="cpu",
+    )
+    lower, upper = rotor_vel_limits(Dynamics.first_principles, sim.drone)
+    assert 0.0 < lower < upper
+
+    # States outside the limits are clipped after the integration
+    for value, target in ((2 * upper, upper), (-upper, lower)):
+        states = sim.data.states.replace(rotor_vel=jnp.full_like(sim.data.states.rotor_vel, value))
+        sim.rotor_vel_control(np.full((1, 1, 4), target))
+        sim.data = sim.data.replace(states=states)
+        sim.step()
+        assert jnp.all(sim.data.states.rotor_vel >= lower)
+        assert jnp.all(sim.data.states.rotor_vel <= upper)
+    sim.close()
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
-    "dynamics", [Dynamics.first_principles, Dynamics.so_rpy_rotor, Dynamics.so_rpy_rotor_drag]
+    "dynamics", [Dynamics.so_rpy, Dynamics.so_rpy_rotor, Dynamics.so_rpy_rotor_drag]
 )
 @pytest.mark.parametrize("integrator", Integrator)
-def test_rotor_vel_clip(dynamics: Dynamics, integrator: Integrator):
-    """Test that the rotor state (RPM or thrust) saturates at its physical limits."""
-    control = Control.rotor_vel if dynamics == Dynamics.first_principles else Control.attitude
-    sim = Sim(dynamics=dynamics, control=control, integrator=integrator, device="cpu")
+def test_thrust_clip(dynamics: Dynamics, integrator: Integrator):
+    """Test that the thrust state of every so_rpy model is clipped to its physical limits."""
+    sim = Sim(dynamics=dynamics, control=Control.attitude, integrator=integrator, device="cpu")
     lower, upper = rotor_vel_limits(dynamics, sim.drone)
     assert 0.0 < lower < upper
 
-    def command(value: float):
-        if dynamics == Dynamics.first_principles:
-            sim.rotor_vel_control(np.full((1, 1, 4), value))
-        else:
-            sim.attitude_control(np.array([[[0.0, 0.0, 0.0, value]]]))
-
-    def rotor_vel() -> Array:
-        # The fitted models only use the first entry of rotor_vel as the collective thrust
-        return (
-            sim.data.states.rotor_vel[..., :1]
-            if dynamics != Dynamics.first_principles
-            else sim.data.states.rotor_vel
-        )
-
-    # Commanding far beyond the upper limit saturates the state exactly at the limit
-    sim.reset()
-    command(10 * upper)
-    for _ in range(200):
-        sim.step()
-        assert jnp.all(sim.data.states.rotor_vel <= upper), "rotor_vel exceeded the upper limit"
-    assert jnp.all(rotor_vel() == upper), f"rotor_vel {rotor_vel()} did not saturate at {upper}"
-    # Commanding below the lower limit saturates at the lower limit. The first principles rotor
-    # dynamics are not linear in the command, so we only test this for the fitted models.
-    if dynamics != Dynamics.first_principles:
-        command(-10 * upper)
-        sim.step(200)
-        assert jnp.all(rotor_vel() == lower), f"rotor_vel {rotor_vel()} did not saturate at {lower}"
-    # States outside the limits are clipped after the integration
     for value, target in ((2 * upper, upper), (-upper, lower)):
-        command(target)
         states = sim.data.states.replace(rotor_vel=jnp.full_like(sim.data.states.rotor_vel, value))
+        sim.attitude_control(np.array([[[0.0, 0.0, 0.0, target]]]))
         sim.data = sim.data.replace(states=states)
         sim.step()
         assert jnp.all(sim.data.states.rotor_vel >= lower)

--- a/tests/unit/test_sim.py
+++ b/tests/unit/test_sim.py
@@ -17,7 +17,7 @@ from crazyflow.exception import ConfigError
 from crazyflow.sim import Dynamics, Sim
 from crazyflow.sim.data import ControlData, SimData
 from crazyflow.sim.integration import Integrator
-from crazyflow.sim.sim import rotor_vel_limits, select_dynamics_fn, sync_sim2mjx, use_box_collision
+from crazyflow.sim.sim import rotor_vel_limits, sync_sim2mjx, use_box_collision
 from crazyflow.sim.visualize import change_material
 
 if TYPE_CHECKING:
@@ -450,47 +450,6 @@ def test_rotor_vel_clip(dynamics: Dynamics, integrator: Integrator):
         sim.step()
         assert jnp.all(sim.data.states.rotor_vel >= lower)
         assert jnp.all(sim.data.states.rotor_vel <= upper)
-    sim.close()
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "dynamics", [Dynamics.first_principles, Dynamics.so_rpy_rotor, Dynamics.so_rpy_rotor_drag]
-)
-def test_rotor_acc_clip(dynamics: Dynamics):
-    """Test that the rotor derivative used by the integrator is clamped at the rotor limits.
-
-    The derivative must be <= 0 at the upper limit, >= 0 at the lower limit, and equal to the raw
-    dynamics derivative in between.
-    """
-    control = Control.rotor_vel if dynamics == Dynamics.first_principles else Control.attitude
-    sim = Sim(dynamics=dynamics, control=control, device="cpu")
-    lower, upper = rotor_vel_limits(dynamics, sim.drone)
-    deriv_fn = sim.step_pipeline["integration"].keywords["deriv_fn"]
-    raw_deriv_fn = select_dynamics_fn(dynamics)
-
-    def command(value: float):
-        if dynamics == Dynamics.first_principles:
-            sim.rotor_vel_control(np.full((1, 1, 4), value))
-        else:
-            sim.attitude_control(np.array([[[0.0, 0.0, 0.0, value]]]))
-        sim.step()  # Commit the staged command
-
-    def rotor_acc(value: float) -> tuple[Array, Array]:
-        states = sim.data.states.replace(rotor_vel=jnp.full_like(sim.data.states.rotor_vel, value))
-        data = sim.data.replace(states=states)
-        return deriv_fn(data).states_deriv.rotor_acc, raw_deriv_fn(data).states_deriv.rotor_acc
-
-    command(10 * upper)
-    acc, raw_acc = rotor_acc(upper)
-    assert jnp.all(raw_acc > 0), "Raw derivative should point beyond the upper limit"
-    assert jnp.all(acc <= 0), f"rotor_acc {acc} points beyond the upper limit"
-    acc, raw_acc = rotor_acc((lower + upper) / 2)
-    assert jnp.all(acc == raw_acc), "rotor_acc must not be modified within the limits"
-    command(0.0)
-    acc, raw_acc = rotor_acc(lower)
-    assert jnp.all(raw_acc < 0), "Raw derivative should point below the lower limit"
-    assert jnp.all(acc >= 0), f"rotor_acc {acc} points below the lower limit"
     sim.close()
 
 

--- a/tests/unit/test_sim.py
+++ b/tests/unit/test_sim.py
@@ -408,8 +408,6 @@ def test_rotor_vel_clip(dynamics: Dynamics, integrator: Integrator):
     sim = Sim(dynamics=dynamics, control=control, integrator=integrator, device="cpu")
     lower, upper = rotor_vel_limits(dynamics, sim.drone)
     assert 0.0 < lower < upper
-    stages = tuple(sim.step_pipeline)
-    assert stages.index("clip_rotor_vel") == stages.index("integration") + 1
 
     def command(value: float):
         if dynamics == Dynamics.first_principles:

--- a/tests/unit/test_sim.py
+++ b/tests/unit/test_sim.py
@@ -16,7 +16,8 @@ from crazyflow.control import Control
 from crazyflow.exception import ConfigError
 from crazyflow.sim import Dynamics, Sim
 from crazyflow.sim.data import ControlData, SimData
-from crazyflow.sim.sim import sync_sim2mjx, use_box_collision
+from crazyflow.sim.integration import Integrator
+from crazyflow.sim.sim import rotor_vel_limits, select_dynamics_fn, sync_sim2mjx, use_box_collision
 from crazyflow.sim.visualize import change_material
 
 if TYPE_CHECKING:
@@ -393,6 +394,103 @@ def test_floor_penetration(dynamics: Dynamics):
     # Check that the drone ended up on the floor (very close to z=0)
     final_z_pos = sim.data.states.pos[..., 2]
     assert jnp.all(final_z_pos == -0.001), f"Drone should be on floor but z={final_z_pos}"
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dynamics", [Dynamics.first_principles, Dynamics.so_rpy_rotor, Dynamics.so_rpy_rotor_drag]
+)
+@pytest.mark.parametrize("integrator", Integrator)
+def test_rotor_vel_clip(dynamics: Dynamics, integrator: Integrator):
+    """Test that the rotor state (RPM or thrust) saturates at its physical limits.
+
+    Commands beyond the limits must not push the state past them, not even transiently, and states
+    that already violate the limits (e.g. set by the user) must be clipped after one step.
+    """
+    control = Control.rotor_vel if dynamics == Dynamics.first_principles else Control.attitude
+    sim = Sim(dynamics=dynamics, control=control, integrator=integrator, device="cpu")
+    lower, upper = rotor_vel_limits(dynamics, sim.drone)
+    assert 0.0 < lower < upper
+    stages = tuple(sim.step_pipeline)
+    assert stages.index("clip_rotor_vel") == stages.index("integration") + 1
+
+    def command(value: float):
+        if dynamics == Dynamics.first_principles:
+            sim.rotor_vel_control(np.full((1, 1, 4), value))
+        else:
+            sim.attitude_control(np.array([[[0.0, 0.0, 0.0, value]]]))
+
+    def rotor_vel() -> Array:
+        # The fitted models only use the first entry of rotor_vel as the collective thrust
+        return (
+            sim.data.states.rotor_vel[..., :1]
+            if dynamics != Dynamics.first_principles
+            else sim.data.states.rotor_vel
+        )
+
+    # Commanding far beyond the upper limit saturates the state exactly at the limit
+    sim.reset()
+    command(10 * upper)
+    for _ in range(200):
+        sim.step()
+        assert jnp.all(sim.data.states.rotor_vel <= upper), "rotor_vel exceeded the upper limit"
+    assert jnp.all(rotor_vel() == upper), f"rotor_vel {rotor_vel()} did not saturate at {upper}"
+    # Commanding below the lower limit saturates at the lower limit. The first principles rotor
+    # dynamics are not linear in the command, so we only test this for the fitted models.
+    if dynamics != Dynamics.first_principles:
+        command(-10 * upper)
+        sim.step(200)
+        assert jnp.all(rotor_vel() == lower), f"rotor_vel {rotor_vel()} did not saturate at {lower}"
+    # States outside the limits are clipped after the integration
+    for value, target in ((2 * upper, upper), (-upper, lower)):
+        command(target)
+        states = sim.data.states.replace(rotor_vel=jnp.full_like(sim.data.states.rotor_vel, value))
+        sim.data = sim.data.replace(states=states)
+        sim.step()
+        assert jnp.all(sim.data.states.rotor_vel >= lower)
+        assert jnp.all(sim.data.states.rotor_vel <= upper)
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dynamics", [Dynamics.first_principles, Dynamics.so_rpy_rotor, Dynamics.so_rpy_rotor_drag]
+)
+def test_rotor_acc_clip(dynamics: Dynamics):
+    """Test that the rotor derivative used by the integrator is clamped at the rotor limits.
+
+    The derivative must be <= 0 at the upper limit, >= 0 at the lower limit, and equal to the raw
+    dynamics derivative in between.
+    """
+    control = Control.rotor_vel if dynamics == Dynamics.first_principles else Control.attitude
+    sim = Sim(dynamics=dynamics, control=control, device="cpu")
+    lower, upper = rotor_vel_limits(dynamics, sim.drone)
+    deriv_fn = sim.step_pipeline["integration"].keywords["deriv_fn"]
+    raw_deriv_fn = select_dynamics_fn(dynamics)
+
+    def command(value: float):
+        if dynamics == Dynamics.first_principles:
+            sim.rotor_vel_control(np.full((1, 1, 4), value))
+        else:
+            sim.attitude_control(np.array([[[0.0, 0.0, 0.0, value]]]))
+        sim.step()  # Commit the staged command
+
+    def rotor_acc(value: float) -> tuple[Array, Array]:
+        states = sim.data.states.replace(rotor_vel=jnp.full_like(sim.data.states.rotor_vel, value))
+        data = sim.data.replace(states=states)
+        return deriv_fn(data).states_deriv.rotor_acc, raw_deriv_fn(data).states_deriv.rotor_acc
+
+    command(10 * upper)
+    acc, raw_acc = rotor_acc(upper)
+    assert jnp.all(raw_acc > 0), "Raw derivative should point beyond the upper limit"
+    assert jnp.all(acc <= 0), f"rotor_acc {acc} points beyond the upper limit"
+    acc, raw_acc = rotor_acc((lower + upper) / 2)
+    assert jnp.all(acc == raw_acc), "rotor_acc must not be modified within the limits"
+    command(0.0)
+    acc, raw_acc = rotor_acc(lower)
+    assert jnp.all(raw_acc < 0), "Raw derivative should point below the lower limit"
+    assert jnp.all(acc >= 0), f"rotor_acc {acc} points below the lower limit"
     sim.close()
 
 

--- a/tests/unit/test_sim.py
+++ b/tests/unit/test_sim.py
@@ -403,11 +403,7 @@ def test_floor_penetration(dynamics: Dynamics):
 )
 @pytest.mark.parametrize("integrator", Integrator)
 def test_rotor_vel_clip(dynamics: Dynamics, integrator: Integrator):
-    """Test that the rotor state (RPM or thrust) saturates at its physical limits.
-
-    Commands beyond the limits must not push the state past them, not even transiently, and states
-    that already violate the limits (e.g. set by the user) must be clipped after one step.
-    """
+    """Test that the rotor state (RPM or thrust) saturates at its physical limits."""
     control = Control.rotor_vel if dynamics == Dynamics.first_principles else Control.attitude
     sim = Sim(dynamics=dynamics, control=control, integrator=integrator, device="cpu")
     lower, upper = rotor_vel_limits(dynamics, sim.drone)


### PR DESCRIPTION
Before there was no explicit clipping of the rotor speed/thrust state. This PR adds this by
1. implementing clipping on the velocity state **after** integration, such that an overshoot in the integration state does not exceed the limits
2. implementing clipping **inside** the integration step, such that the derivative is clipped in case we are already at the bounds to prevent further overshoots.

There are two minor problems with this approach
1. the clipping inside the integration step cannot simply be removed from the step pipeline, since it's baked in.
2. in case the state is still in bounds, a large command is applied, and an integration method besides Euler is used, the effective acceleration on the mass can still exceed the actuator limits for one sim step.